### PR TITLE
Linux/Unix shell compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ the virtual environment.
 
     * Ansible>=2.0,<3.0
     * boto
-    * molecule
 
 
 ## Usage

--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-app="$( cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )" && pwd )"
+app=$( cd "$(dirname "$0")" ; pwd -P )
 source "${app}/src/txt.sh"
 
 # Setup python virtual-env for setting up dependencies

--- a/install
+++ b/install
@@ -10,7 +10,7 @@ is_ok
 
 # Create a python virtual environment
 note "Creating virtual environment.."
-virtualenv -q .venv
+virtualenv -q "${app}/.venv"
 is_ok
 
 # Enable the virtual environment
@@ -21,5 +21,5 @@ is_ok
 
 # Then install with pip will be inside that virtual environment
 note "Installing requirements.."
-pip install -qIr requirements.txt
+pip install -qIr "${app}/requirements.txt"
 is_ok

--- a/launch
+++ b/launch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-app="$( cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )" && pwd )"
+app=$( cd "$(dirname "$0")" ; pwd -P )
 source "${app}/src/txt.sh"
 source "${app}/src/common.sh"
 

--- a/src/common.sh
+++ b/src/common.sh
@@ -1,5 +1,5 @@
 # This file both sets common variables _and_ executes modules, it must be safe to run multiple times
-# TODO: consider breaking this into an 'init' and 'exec' module
+# TODO: consider breaking this into an 'init' and 'activate' module
 
 source "${app}/src/txt.sh"
 

--- a/src/txt.sh
+++ b/src/txt.sh
@@ -3,37 +3,37 @@
 # Check status of previous command and return a success/error note
 function is_ok() {
     if [[ $? -eq 0 ]]; then
-        echo -e " \e[92mOK\e[0m"
+        printf " \e[92mOK\e[0m\n"
     else
-        echo -e " \e[91mERROR\e[0m"
+        printf " \e[91mERROR\e[0m\n"
     fi
 }
 
 # Displays text highlighted; no new-line
 function note() {
-    echo -en "\e[94m$1\e[0m"
+    printf "\e[94m$1\e[0m"
 }
 
 # Displays a highlighted title text; includes a new-line
 function title() {
-    echo -e "\e[93m$1\e[0m"
+    printf "\e[93m$1\e[0m\n"
 }
 
 # Displays text in red; no new-line
 function err() {
-    echo -en "\e[91m$1\e[0m"
+    printf "\e[91m$1\e[0m"
 }
 
 # Only output if verbose logging enabled
 function log() {
     if [[ "${VERBOSE}" -eq 1 ]]; then
-        echo -e "\e[37m$1\e[0m"
+        printf "\e[37m$1\e[0m\n"
     fi
 }
 
 # Only output if verbose logging enabled; no new-line
 function log_n() {
     if [[ "${VERBOSE}" -eq 1 ]]; then
-        echo -en "\e[37m$1\e[0m"
+        printf "\e[37m$1\e[0m"
     fi
 }

--- a/teardown
+++ b/teardown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-app="$( cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )" && pwd )"
+app=$( cd "$(dirname "$0")" ; pwd -P )
 source "${app}/src/txt.sh"
 source "${app}/src/common.sh"
 


### PR DESCRIPTION
- Fixed real-path resolution issues on OSX due to `readlink -f`. Fix doesn't do symbolic link resolution but will work under most situations.

- `echo` on OSX/Unix seems to have different character escaping implementation. So switched to `printf` which should work on Linux as well.